### PR TITLE
Add DoubleEndedIterator for array_windows

### DIFF
--- a/crates/arrays/src/lib.rs
+++ b/crates/arrays/src/lib.rs
@@ -21,32 +21,33 @@
 use core::hint;
 use core::mem;
 use core::mem::MaybeUninit;
+use core::ops::Range;
 use core::ptr;
 
-/// Consumes `N` elements from the iterator and returns them as an array. If the
-/// iterator yields fewer than `N` items, `None` is returned and all already
-/// yielded items are dropped.
+/// # Safety
 ///
-/// # Panics
+/// Caller must ensure the following invariant:
 ///
-/// If the iterator panics then all already yielded elements will be dropped.
+/// * `idxs` only returns indices in range 0..N
+/// * `curr_idx_to_range` will, for any given index given by `idxs`,
+///    return a range which exactly contains the indices yielded so far
 ///
-// Based on the array collect implementation in the Rust standard library.
-// https://github.com/rust-lang/rust/blob/master/library/core/src/array/mod.rs#L476-L531
-#[inline]
-pub fn collect<I, T, const N: usize>(mut iter: I) -> Option<[T; N]>
-where
-    I: Iterator<Item = T>,
-{
+/// Essentially, we can use `idxs` and `curr_idx_to_range` to properly write the
+/// items to the array in the right order and drop them if we don't get enough.
+unsafe fn collect_impl<T, const N: usize>(
+    mut next: impl FnMut() -> Option<T>,
+    idxs: impl Iterator<Item = usize>,
+    curr_idx_to_range: impl Fn(usize) -> Range<usize>,
+) -> Option<[T; N]> {
     struct Guard<'a, T, const N: usize> {
         array: &'a mut [MaybeUninit<T>; N],
-        init: usize,
+        init: Range<usize>,
     }
 
     impl<T, const N: usize> Drop for Guard<'_, T, N> {
         fn drop(&mut self) {
-            for elem in &mut self.array.as_mut_slice()[..self.init] {
-                // SAFETY: this raw slice up to `self.len` will only contain
+            for elem in &mut self.array.as_mut_slice()[self.init.clone()] {
+                // SAFETY: this raw slice defined by `self.init` will only contain
                 // the initialized objects.
                 unsafe { ptr::drop_in_place(elem.as_mut_ptr()) };
             }
@@ -67,17 +68,19 @@ where
 
     let mut guard = Guard {
         array: &mut array,
-        init: 0,
+
+        // any empty range will work
+        init: 0..0,
     };
 
-    for _ in 0..N {
-        match iter.next() {
+    for idx in idxs {
+        match next() {
             Some(item) => {
                 // SAFETY: `guard.init` starts at zero, is increased by 1 each
                 // iteration of the loop, and the loop is aborted once M * N
                 // is reached, which is the length of the array.
-                unsafe { guard.array.get_unchecked_mut(guard.init).write(item) };
-                guard.init += 1;
+                unsafe { guard.array.get_unchecked_mut(idx).write(item) };
+                guard.init = curr_idx_to_range(idx);
             }
             None => {
                 return None;
@@ -90,6 +93,42 @@ where
     // SAFETY: the loop above loops exactly N times which is the size of the
     // array, so all elements in the array are initialized.
     Some(unsafe { transmute_unchecked(array) })
+}
+
+/// Consumes `N` elements from the iterator and returns them as an array. If the
+/// iterator yields fewer than `N` items, `None` is returned and all already
+/// yielded items are dropped.
+///
+/// # Panics
+///
+/// If the iterator panics then all already yielded elements will be dropped.
+///
+// Based on the array collect implementation in the Rust standard library.
+// https://github.com/rust-lang/rust/blob/master/library/core/src/array/mod.rs#L476-L531
+#[inline]
+pub fn collect<I, T, const N: usize>(mut iter: I) -> Option<[T; N]>
+where
+    I: Iterator<Item = T>,
+{
+    unsafe { collect_impl(move || iter.next(), 0..N, |i| 0..i + 1) }
+}
+
+/// Consumes `N` elements from the iterator and returns them as an array in
+/// reverse order. If the iterator yields fewer than `N` items, `None` is
+/// returned and all already yielded items are dropped.
+///
+/// # Panics
+///
+/// If the iterator panics then all already yielded elements will be dropped.
+///
+// Based on the array collect implementation in the Rust standard library.
+// https://github.com/rust-lang/rust/blob/master/library/core/src/array/mod.rs#L476-L531
+#[inline]
+pub fn collect_reversed<I, T, const N: usize>(mut iter: I) -> Option<[T; N]>
+where
+    I: Iterator<Item = T>,
+{
+    unsafe { collect_impl(move || iter.next(), (0..N).rev(), |i| i..N) }
 }
 
 /// Consumes `N` elements from the iterator and returns them as an array.
@@ -108,6 +147,30 @@ where
     I: Iterator<Item = T>,
 {
     match collect(iter) {
+        Some(arr) => arr,
+        None =>
+        // SAFETY: Guaranteed by the caller.
+        unsafe { hint::unreachable_unchecked() },
+    }
+}
+
+/// Consumes `N` elements from the iterator and returns them as an array in
+/// reverse order.
+///
+/// # Safety
+///
+/// This function is the same as [`collect_reversed`] but the caller must guarantee
+/// that the iterator yields at least N items.
+///
+/// # Panics
+///
+/// If the iterator panics then all already yielded elements will be dropped.
+#[inline]
+pub unsafe fn collect_reversed_unchecked<I, T, const N: usize>(iter: I) -> [T; N]
+where
+    I: Iterator<Item = T>,
+{
+    match collect_reversed(iter) {
         Some(arr) => arr,
         None =>
         // SAFETY: Guaranteed by the caller.

--- a/crates/windows/Cargo.toml
+++ b/crates/windows/Cargo.toml
@@ -13,3 +13,7 @@ categories = ["algorithms", "rust-patterns"]
 
 [dependencies]
 arrays = { path = "../arrays", version = "0.1.0"}
+
+[dev-dependencies]
+proptest = "1.0.0"
+rand = "0.8.5"

--- a/crates/windows/src/lib.rs
+++ b/crates/windows/src/lib.rs
@@ -123,6 +123,7 @@ where
         }
     }
 
+    /// After `iter` is exhausted, this provides the `next` value.
     fn next_overlapping(
         prev_back: &mut Option<[I::Item; N]>,
         overlap: &mut usize,
@@ -137,6 +138,7 @@ where
         None
     }
 
+    /// After `iter` is exhausted, this provides the `next_back` value.
     fn next_back_overlapping(
         prev: &mut Option<[I::Item; N]>,
         overlap: &mut usize,
@@ -144,13 +146,14 @@ where
         if *overlap < N {
             if let Some(prev) = prev {
                 *overlap += 1;
-                let item = prev[prev.len() - *overlap].clone();
+                let item = prev[N - *overlap].clone();
                 return Some(item);
             }
         }
         None
     }
 
+    /// Number of items contained within `prev` and `prev_back` combined.
     fn extra_len(&self) -> usize {
         let prev_len = self.prev.as_ref().map_or(0, |p| p.len());
         let prev_back_len = self.prev_back.as_ref().map_or(0, |p| p.len());
@@ -180,7 +183,7 @@ where
                     .next()
                     .or_else(|| Self::next_overlapping(prev_back, overlap))?;
                 prev.rotate_left(1);
-                prev[prev.len() - 1] = item;
+                prev[N - 1] = item;
                 Some(prev.clone())
             }
             None => {
@@ -227,14 +230,14 @@ where
         match prev_back {
             Some(prev_back) => {
                 let item = iter
-                    .next()
+                    .next_back()
                     .or_else(|| Self::next_back_overlapping(prev, overlap))?;
                 prev_back.rotate_right(1);
                 prev_back[0] = item;
                 Some(prev_back.clone())
             }
             None => {
-                let tmp = arrays::collect(iter.chain(core::iter::from_fn(|| {
+                let tmp = arrays::collect_reversed(iter.rev().chain(core::iter::from_fn(|| {
                     Self::next_back_overlapping(prev, overlap)
                 })))?;
                 *prev_back = Some(tmp.clone());

--- a/crates/windows/src/lib.rs
+++ b/crates/windows/src/lib.rs
@@ -153,6 +153,9 @@ where
         None
     }
 
+    /// Compute a `size_hint` or `len` based upon a given iterator size.
+    ///
+    /// Common code between `size_hint` and `len`
     fn compute_len(
         iter_len: usize,
         prev: &Option<[I::Item; N]>,
@@ -160,15 +163,17 @@ where
         overlap: usize,
     ) -> usize {
         match (prev, prev_back) {
-            // fresh iteration; we will pull one of these out to make room
-            // for a new window
+            // fresh iteration;
+            // needs to pull out a new window before we can have an accurate estimate
             (None, None) => iter_len.saturating_sub(N - 1),
 
-            // unidirectional iteration; number of windows equals number of items left
+            // unidirectional iteration;
+            // number of windows equals number of items left
             (Some(_), None) | (None, Some(_)) => iter_len,
 
-            // finished iteration; account for overlap
-            (Some(_), Some(_)) => iter_len + (N - overlap - 1),
+            // bidirectional iteration;
+            // account for overlap
+            (Some(_), Some(_)) => iter_len + (N - 1 - overlap),
         }
     }
 }
@@ -270,6 +275,3 @@ where
         }
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/crates/windows/tests/random.rs
+++ b/crates/windows/tests/random.rs
@@ -1,0 +1,63 @@
+use iterwindows::IterArrayWindows;
+use rand::Rng;
+
+/// Randomly call `iter` and `iter_next`.
+fn test_iter<A: IntoIterator, E: IntoIterator<Item = A::Item>>(
+    prob: f64,
+    actual: A,
+    expected: E,
+) -> proptest::test_runner::TestCaseResult
+where
+    A::IntoIter: DoubleEndedIterator,
+    A::Item: std::fmt::Debug + PartialEq,
+{
+    let mut rng = rand::thread_rng();
+    let expected = Vec::from_iter(expected.into_iter());
+
+    let mut actual_iter = actual.into_iter();
+    let mut actual = std::collections::VecDeque::new();
+    let mut count = expected.len();
+    let mut rotate = 0;
+    loop {
+        if rng.gen_bool(prob) {
+            let Some(item) = actual_iter.next() else { break };
+            actual.push_back(item);
+            //count -= 1;
+            //proptest::prop_assert_eq!(actual_iter.size_hint(), (count, Some(count)));
+        } else {
+            let Some(item) = actual_iter.next_back() else { break };
+            actual.push_front(item);
+            rotate += 1;
+            // count -= 1;
+            // proptest::prop_assert_eq!(actual_iter.size_hint(), (count, Some(count)));
+        }
+    }
+
+    actual.rotate_left(rotate);
+    proptest::prop_assert_eq!(&actual.make_contiguous()[..], &expected[..]);
+
+    Ok(())
+}
+
+proptest::proptest! {
+    #[test]
+    fn test_next(vals: Vec<u8>) {
+        let actual = vals.iter().copied().array_windows::<5>().map(|w| w.to_vec());
+        let expected = vals.windows(5).map(|w| w.to_vec());
+        test_iter(1.0, actual, expected)?;
+    }
+
+    #[test]
+    fn test_next_back(vals: Vec<u8>) {
+        let actual = vals.iter().copied().array_windows::<5>().map(|w| w.to_vec());
+        let expected = vals.windows(5).map(|w| w.to_vec());
+        test_iter(0.0, actual, expected)?;
+    }
+
+    #[test]
+    fn test_both_directions(vals: Vec<u8>) {
+        let actual = vals.iter().copied().array_windows::<5>().map(|w| w.to_vec());
+        let expected = vals.windows(5).map(|w| w.to_vec());
+        test_iter(0.5, actual, expected)?;
+    }
+}


### PR DESCRIPTION
## API changes

* `iterwindows::ArrayWindows` now implements `DoubleEndedIterator`
* `arrays::collect_reversed` and `arrays::collect_reversed_unchecked` added, which are identical to `collect` and `collect_unchecked` but return their arrays in reverse order. This is an implementation detail that I figured was worth exposing, since `arrays::collect` is already exposed publicly. This avoids having to manually reverse the elements of backwards windows after the fact.

## Implementation details

Since we're already relying on the items from the iterator being `Clone`, we just keep multiple copies of iterands when we overlap the stored windows after iterating from both ends.

I copied in some proptest code that I've used across other projects before which will randomly choose between `next` and `next_back` on the iterator, then verify that no matter what order we choose, the resulting list of elements will still be the same. This is a great way of stress-testing the implementation and I used it to squash out all of the remaining bugs.

It's a little messy, but I've factored out repeated code sections into their own functions. I'm open to suggestions on how to clean this up, since they involve a lot of weird variable choices, but I've hopefully documented them well enough that a passive observer will understand what's going on. (Since a passive observer will be reviewing this, let me know if I was successful!)